### PR TITLE
handle liquibase return codes as an exception

### DIFF
--- a/liquimigrate/management/commands/liquibase.py
+++ b/liquimigrate/management/commands/liquibase.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+
 try:
     # Django 1.7
     from django.core.management.sql import (emit_pre_migrate_signal,
@@ -154,6 +155,8 @@ class Command(BaseCommand):
 
                 call_command('loaddata', 'initial_data',
                     verbosity=0)
+        else:
+            raise CommandError('Liquibase returned an error code %s' % rc)
 
 
 def _get_url_for_db(tag, dbsettings):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='liquimigrate',
-    version='0.5.0',
+    version='0.5.1',
     description="Liquibase migrations with django",
     long_description=readme + '\n\n' + history,
     author="Marek Wywiał",


### PR DESCRIPTION
Liquibase zwraca return codes, ale one "gubią się" przy wyjściu z mgmt command. 
Ma to istotne znaczenie, kiedy używasz liquimigrate w CI (np. Jenkins), bo mgmt command nie wywala błędu.
W mgmt command trzeba rzucić wyjątkiem, aby Django wyszło exitcode (1), co rozwiązuje problem z CI.
