### PR TITLE
makechangesets command

### DIFF
--- a/liquimigrate/changesets.py
+++ b/liquimigrate/changesets.py
@@ -1,0 +1,220 @@
+import os
+
+from string import Template
+
+from xml.dom import minidom
+from xml.parsers.expat import ExpatError
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db import DEFAULT_DB_ALIAS
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.loader import MigrationLoader
+
+
+class NoMigrationsFound(Exception):
+    pass
+
+
+class InvalidChangelogFile(Exception):
+    pass
+
+
+def validate_app_names(loader, app_names):
+    invalid_apps = []
+    for app_name in app_names:
+        if app_name not in loader.migrated_apps:
+            invalid_apps.append(app_name)
+    if invalid_apps:
+        raise NoMigrationsFound(
+                'No migrations present for: %s' % (
+                    ', '.join(sorted(invalid_apps))))
+
+
+def generate_changesets_text(
+        connection, app_names=None, author=None, fake=False,
+        skip_errors=False, indent=''):
+
+    author = author or os.getlogin()
+
+    loader = MigrationLoader(connection)
+    graph = loader.graph
+
+    if app_names:
+        validate_app_names(loader, app_names)
+
+        targets = [
+                key for key in graph.leaf_nodes()
+                if key[0] in app_names]
+    else:
+        targets = graph.leaf_nodes()
+    plan = []
+    seen = set()
+
+    # Generate the plan
+    for target in targets:
+        for migration in graph.forwards_plan(target):
+            if migration not in seen:
+                node = graph.node_map[migration]
+                plan.append(node)
+                seen.add(migration)
+
+    to_generate = []
+
+    for node in plan:
+        if node.key not in loader.applied_migrations:
+            to_generate.append(node)
+
+    executor = MigrationExecutor(connection)
+
+    def cdata_lines(lines, indentation_level=2):
+        indent_str = indentation_level * indent
+        separator = u'\n%s' % indent_str
+        if len(lines) > 1:
+            return u'\n%s%s\n' % (indent_str, separator.join(lines))
+        else:
+            return lines[0]
+
+    outputs = []
+
+    changesett = Template(
+        '$indent<changeSet author="$author" id="$id">$body$indent</changeSet>')
+    cdatat = Template('<![CDATA[$body]]>')
+    sqlt = Template('$indent$indent<sql>$body</sql>')
+    rollbackt = Template(
+        '$indent$indent<rollback>\n$indent$body\n$indent$indent</rollback>')
+
+    forwardt = Template(
+            'insert into django_migrations (app, name, applied) '
+            'values (\'$app_label\', \'$migration_name\', now())')
+    backwardt = Template(
+            'delete from django_migrations where '
+            'app=\'$app_label\' and name=\'$migration_name\'')
+
+    for app_label, name in to_generate:
+        migration = executor.loader.get_migration_by_prefix(
+                                                    app_label, name)
+        targets = [(app_label, migration.name)]
+        forward_plan = [(executor.loader.graph.nodes[targets[0]], False)]
+        backward_plan = [(executor.loader.graph.nodes[targets[0]], True)]
+
+        try:
+            sql_forward = executor.collect_sql(forward_plan)
+        except Exception as ex:
+            if skip_errors:
+                sql_forward = ['-- skipped due to exception: %s' % ex]
+            else:
+                raise
+
+        try:
+            sql_backward = executor.collect_sql(backward_plan)
+        except Exception as ex:
+            if skip_errors:
+                sql_backward = ['-- skipped due to exception: %s' % ex]
+            else:
+                raise
+
+        changeset_id = u'django-%s-%s' % (app_label, migration.name)
+
+        if fake:
+            changeset_id += '-faked'
+
+        ctx = {
+                'indent': indent,
+                'id': changeset_id,
+                'author': author,
+                'app_label': app_label,
+                'migration_name': migration.name,
+                }
+
+        def rendertpl(tpl, **extra):
+            tplctx = dict(ctx)
+            tplctx.update(extra)
+            return tpl.substitute(tplctx)
+
+        changeset_parts = []
+
+        if not fake:
+            changeset_parts.append(u'\n'+rendertpl(sqlt, body=rendertpl(
+                cdatat, body=cdata_lines(
+                    sql_forward, indentation_level=2)+indent*2)))
+
+        changeset_parts.append(rendertpl(sqlt, body=rendertpl(forwardt)))
+
+        rollback_parts = []
+
+        if not fake:
+            rollback_parts.append(rendertpl(sqlt, body=rendertpl(
+                cdatat, body=cdata_lines(
+                    sql_backward, indentation_level=3)+indent*3)))
+
+        rollback_parts.append(
+                indent+rendertpl(sqlt, body=rendertpl(backwardt)))
+
+        sep = u'\n'
+        changeset_parts.append(rendertpl(
+            rollbackt, body=sep.join(rollback_parts)))
+        outputs.append(rendertpl(
+            changesett, body=sep.join(changeset_parts)+u'\n'))
+    return u'\n'.join(outputs)
+
+
+def get_changelog_file_for_database(database=DEFAULT_DB_ALIAS):
+    """get changelog filename for given `database` DB alias"""
+
+    from django.conf import settings
+
+    try:
+        return settings.LIQUIMIGRATE_CHANGELOG_FILES[database]
+    except AttributeError:
+        if database == DEFAULT_DB_ALIAS:
+            try:
+                return settings.LIQUIMIGRATE_CHANGELOG_FILE
+            except AttributeError:
+                raise ImproperlyConfigured(
+                        'Please set LIQUIMIGRATE_CHANGELOG_FILE or '
+                        'LIQUIMIGRATE_CHANGELOG_FILES in your '
+                        'project settings')
+        else:
+            raise ImproperlyConfigured(
+                'LIQUIMIGRATE_CHANGELOG_FILES dictionary setting '
+                'is required for multiple databases support')
+    except KeyError:
+        raise ImproperlyConfigured(
+            "Liquibase changelog file is not set for database: %s" % database)
+
+
+def find_target_migration_file(database=DEFAULT_DB_ALIAS, changelog_file=None):
+    """Finds best matching target migration file"""
+
+    if not database:
+        database = DEFAULT_DB_ALIAS
+
+    if not changelog_file:
+        changelog_file = get_changelog_file_for_database(database)
+
+    try:
+        doc = minidom.parse(changelog_file)
+    except ExpatError as ex:
+        raise InvalidChangelogFile(
+                'Could not parse XML file %s: %s' % (changelog_file, ex))
+
+    try:
+        dbchglog = doc.getElementsByTagName('databaseChangeLog')[0]
+    except IndexError:
+        raise InvalidChangelogFile(
+            'Missing <databaseChangeLog> node in file %s' % (
+                                                    changelog_file))
+    else:
+        nodes = list(filter(lambda x: x.nodeType is x.ELEMENT_NODE,
+                            dbchglog.childNodes))
+        if not nodes:
+            return changelog_file
+
+        last_node = nodes[-1]
+
+        if last_node.tagName == 'include':
+            last_file = last_node.attributes.get('file').firstChild.data
+            return find_target_migration_file(
+                    database=database, changelog_file=last_file)
+        else:
+            return changelog_file

--- a/liquimigrate/management/commands/base.py
+++ b/liquimigrate/management/commands/base.py
@@ -1,0 +1,47 @@
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DEFAULT_DB_ALIAS, connections
+
+from ... import changesets
+
+
+class BaseChangesetCommand(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'app_label', nargs='*',
+            help='App labels of applications to limit the output to.',
+        )
+        parser.add_argument(
+            '--author', action='store', default=os.getlogin(),
+            help='Migrations author (defaults to username)',
+        )
+        parser.add_argument(
+            '--fake', action='store_true', default=False,
+            help='Create fake changesets (mark migrations ran)',
+        )
+        parser.add_argument(
+            '--skip-errors', action='store_true', default=False,
+            help='Skip SQL creation erros',
+        )
+        parser.add_argument(
+            '--database', action='store', dest='database',
+            default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to synchronize. '
+                 'Defaults to the "default" database.',
+        )
+        parser.add_argument(
+            '--indent', action='store', default='    ',
+            help='Indentation characters (defaults to four spaces)',
+        )
+
+    def handle(self, *args, **options):
+        db = options['database']
+        connection = connections[db]
+        app_names = options.pop('app_label')
+
+        try:
+            self.handle_changeset_command(connection, app_names, **options)
+        except changesets.NoMigrationsFound as ex:
+            raise CommandError(ex)

--- a/liquimigrate/management/commands/liquibase.py
+++ b/liquimigrate/management/commands/liquibase.py
@@ -6,7 +6,9 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
 
-from liquimigrate.settings import LIQUIBASE_JAR, LIQUIBASE_DRIVERS
+from ...settings import LIQUIBASE_JAR, LIQUIBASE_DRIVERS
+from ... import changesets
+
 
 try:
     # Django 3.7
@@ -206,16 +208,6 @@ def _get_url_for_db(tag, dbsettings):
 
 def _get_changelog_file(database):
     try:
-        return settings.LIQUIMIGRATE_CHANGELOG_FILES[database]
-    except AttributeError:
-        if database == 'default':
-            try:
-                return settings.LIQUIMIGRATE_CHANGELOG_FILE
-            except AttributeError:
-                raise CommandError('give me changelog somehow')
-        else:
-            raise CommandError('settings.LIQUIMIGRATE_CHANGELOG_FILES dict \
-                    is needed due to multidb operation')
-    except KeyError:
-        raise CommandError(
-                "don't know changelog for connection: %s" % database)
+        return changesets.get_changelog_file_for_database(database)
+    except changesets.ImproperlyConfigured as ex:
+        raise CommandError(ex)

--- a/liquimigrate/management/commands/makechangesets.py
+++ b/liquimigrate/management/commands/makechangesets.py
@@ -1,140 +1,45 @@
-import os
+from __future__ import absolute_import
 
-from django.core.management.base import BaseCommand, CommandError
-from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.migrations.executor import MigrationExecutor
-from django.db.migrations.loader import MigrationLoader
+from xml.dom import minidom
+from xml.parsers.expat import ExpatError
+
+from .base import BaseChangesetCommand, CommandError
+from ... import changesets
 
 
-class Command(BaseCommand):
-    help = "Generates SQL changesets for each unapplied Django migration"
+class Command(BaseChangesetCommand):
+    help = "Creates Liquibase changesets for each unapplied Django migration"
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            'app_label', nargs='*',
-            help='App labels of applications to limit the output to.',
-        )
-        parser.add_argument(
-            '--author', action='store', default=os.getlogin(),
-            help='Migrations author (defaults to username)',
-        )
-        parser.add_argument(
-            '--fake', action='store_true', default=False,
-            help='Create fake changesets (mark migrations ran)',
-        )
-        parser.add_argument(
-            '--skip-errors', action='store_true', default=False,
-            help='Skip SQL creation erros',
-        )
-        parser.add_argument(
-            '--database', action='store', dest='database',
-            default=DEFAULT_DB_ALIAS,
-            help='Nominates a database to synchronize. '
-                 'Defaults to the "default" database.',
-        )
+    def handle_changeset_command(self, connection, app_names, **options):
+        target = changesets.find_target_migration_file(
+                                    database=options['database'])
+        migration_str = changesets.generate_changesets_text(
+                connection, app_names, fake=options['fake'],
+                skip_errors=options['skip_errors'], author=options['author'],
+                indent=options['indent'])
 
-    def handle(self, *args, **options):
-        db = options['database']
-        connection = connections[db]
-        app_names = options['app_label']
-        author = options['author'] or os.getlogin()
-        fake = options['fake']
+        if migration_str:
+            try:
+                doc = minidom.parse(target)
+            except ExpatError as ex:
+                raise CommandError(
+                        'Incorrect syntax of target XML file: %s' % ex)
 
-        self.generate_changesets(
-                connection, app_names, author, fake, options['skip_errors'])
+            nodes = doc.getElementsByTagName('databaseChangeLog')
+            if not nodes:
+                raise CommandError(
+                        'File %s is missing databaseChangeLog' % target)
 
-    def _validate_app_names(self, loader, app_names):
-        invalid_apps = []
-        for app_name in app_names:
-            if app_name not in loader.migrated_apps:
-                invalid_apps.append(app_name)
-        if invalid_apps:
-            raise CommandError(
-                    'No migrations present for: %s' % (
-                        ', '.join(sorted(invalid_apps))))
+            with open(target, 'r') as fh:
+                original = fh.read()
 
-    def generate_changesets(
-            self, connection, app_names, author, fake, skip_errors):
+            updated = original.replace(
+                            '</databaseChangeLog>',
+                            '%s\n</databaseChangeLog>' % migration_str)
 
-        loader = MigrationLoader(connection)
-        graph = loader.graph
-        if app_names:
-            self._validate_app_names(loader, app_names)
-            targets = [
-                    key for key in graph.leaf_nodes()
-                    if key[0] in app_names]
+            with open(target, 'w') as fh:
+                fh.write(updated)
+
+            print("A new changesets were added to file %s" % target)
         else:
-            targets = graph.leaf_nodes()
-        plan = []
-        seen = set()
-
-        # Generate the plan
-        for target in targets:
-            for migration in graph.forwards_plan(target):
-                if migration not in seen:
-                    node = graph.node_map[migration]
-                    plan.append(node)
-                    seen.add(migration)
-
-        to_generate = []
-
-        for node in plan:
-            if node.key not in loader.applied_migrations:
-                to_generate.append(node)
-
-        executor = MigrationExecutor(connection)
-
-        for app_label, name in to_generate:
-            migration = executor.loader.get_migration_by_prefix(
-                                                        app_label, name)
-            self.output_transaction = migration.atomic
-
-            targets = [(app_label, migration.name)]
-            forward_plan = [(executor.loader.graph.nodes[targets[0]], False)]
-            backward_plan = [(executor.loader.graph.nodes[targets[0]], True)]
-
-            try:
-                sql_forward = executor.collect_sql(forward_plan)
-            except Exception as ex:
-                if skip_errors:
-                    sql_forward = ['-- skipped due to exception: %s' % ex]
-                else:
-                    raise
-
-            try:
-                sql_backward = executor.collect_sql(backward_plan)
-            except Exception as ex:
-                if skip_errors:
-                    sql_backward = ['-- skipped due to exception: %s' % ex]
-                else:
-                    raise
-
-            changeset_id = u'django-%s-%s' % (app_label, migration.name)
-
-            if fake:
-                changeset_id += '-faked'
-
-            forward_version = (
-                    'insert into django_migrations (app, name, applied) '
-                    'values (\'%s\', \'%s\', now());' % (
-                        app_label, migration.name))
-            backward_version = (
-                    'delete from django_migrations where '
-                    'app=\'%s\' and name=\'%s\';' % (
-                            app_label, migration.name))
-
-            print('    <changeSet id="%s" author="%s">' % (
-                                            changeset_id, author))
-            if not fake:
-                print('        <sql><![CDATA[')
-                print('            '+'\n            '.join(sql_forward))
-                print('        ]]></sql>')
-            print('        <sql>%s</sql>' % forward_version)
-            print('        <rollback>')
-            if not fake:
-                print('            <sql><![CDATA[')
-                print('            '+'\n            '.join(sql_backward))
-                print('            ]]></sql>')
-            print('            <sql>%s</sql>' % backward_version)
-            print('        </rollback>')
-            print('    </changeSet>')
+            print("No changesets were added.")

--- a/liquimigrate/management/commands/makechangesets.py
+++ b/liquimigrate/management/commands/makechangesets.py
@@ -1,0 +1,106 @@
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.loader import MigrationLoader
+
+
+class Command(BaseCommand):
+    help = "Generates SQL changesets for each unapplied Django migration"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'app_label', nargs='*',
+            help='App labels of applications to limit the output to.',
+        )
+        parser.add_argument(
+            '--author', action='store', default=os.getlogin(),
+            help='Migrations author (defaults to username)',
+        )
+        parser.add_argument(
+            '--database', action='store', dest='database',
+            default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to synchronize. '
+                 'Defaults to the "default" database.',
+        )
+
+    def handle(self, *args, **options):
+        db = options['database']
+        connection = connections[db]
+        app_names = options['app_label']
+        author = options['author'] or os.getlogin()
+
+        self.generate_changesets(connection, app_names, author)
+
+    def _validate_app_names(self, loader, app_names, author):
+        invalid_apps = []
+        for app_name in app_names:
+            if app_name not in loader.migrated_apps:
+                invalid_apps.append(app_name)
+        if invalid_apps:
+            raise CommandError(
+                    'No migrations present for: %s' % (
+                        ', '.join(sorted(invalid_apps))))
+
+    def generate_changesets(self, connection, app_names, author):
+        loader = MigrationLoader(connection)
+        graph = loader.graph
+        if app_names:
+            self._validate_app_names(loader, app_names)
+            targets = [
+                    key for key in graph.leaf_nodes()
+                    if key[0] in app_names]
+        else:
+            targets = graph.leaf_nodes()
+        plan = []
+        seen = set()
+
+        # Generate the plan
+        for target in targets:
+            for migration in graph.forwards_plan(target):
+                if migration not in seen:
+                    node = graph.node_map[migration]
+                    plan.append(node)
+                    seen.add(migration)
+
+        to_generate = []
+
+        for node in plan:
+            if node.key not in loader.applied_migrations:
+                to_generate.append(node)
+
+        executor = MigrationExecutor(connection)
+
+        for app_label, name in to_generate:
+            migration = executor.loader.get_migration_by_prefix(
+                                                        app_label, name)
+            targets = [(app_label, migration.name)]
+            forward_plan = [(executor.loader.graph.nodes[targets[0]], False)]
+            backward_plan = [(executor.loader.graph.nodes[targets[0]], True)]
+
+            sql_forward = executor.collect_sql(forward_plan)
+            sql_backward = executor.collect_sql(backward_plan)
+
+            forward_version = (
+                    'insert into django_migrations (app, name, applied) '
+                    'values (\'%s\', \'%s\', now());' % (
+                        app_label, migration.name))
+            backward_version = (
+                    'delete from django_migrations where '
+                    'app=\'%s\' and name=\'%s\';' % (
+                            app_label, migration.name))
+
+            print('    <changeSet id="django-%s-%s" author="%s">' % (
+                app_label, migration.name, author))
+            print('        <sql><![CDATA[')
+            print('            '+'\n            '.join(sql_forward))
+            print('        ]]></sql>')
+            print('        <sql>%s</sql>' % forward_version)
+            print('        <rollback>')
+            print('            <sql><![CDATA[')
+            print('            '+'\n            '.join(sql_backward))
+            print('            ]]></sql>')
+            print('            <sql>%s</sql>' % backward_version)
+            print('        </rollback>')
+            print('    </changeSet>')

--- a/liquimigrate/management/commands/makechangesets.py
+++ b/liquimigrate/management/commands/makechangesets.py
@@ -19,6 +19,14 @@ class Command(BaseCommand):
             help='Migrations author (defaults to username)',
         )
         parser.add_argument(
+            '--fake', action='store_true', default=False,
+            help='Create fake changesets (mark migrations ran)',
+        )
+        parser.add_argument(
+            '--skip-errors', action='store_true', default=False,
+            help='Skip SQL creation erros',
+        )
+        parser.add_argument(
             '--database', action='store', dest='database',
             default=DEFAULT_DB_ALIAS,
             help='Nominates a database to synchronize. '
@@ -30,10 +38,12 @@ class Command(BaseCommand):
         connection = connections[db]
         app_names = options['app_label']
         author = options['author'] or os.getlogin()
+        fake = options['fake']
 
-        self.generate_changesets(connection, app_names, author)
+        self.generate_changesets(
+                connection, app_names, author, fake, options['skip_errors'])
 
-    def _validate_app_names(self, loader, app_names, author):
+    def _validate_app_names(self, loader, app_names):
         invalid_apps = []
         for app_name in app_names:
             if app_name not in loader.migrated_apps:
@@ -43,7 +53,9 @@ class Command(BaseCommand):
                     'No migrations present for: %s' % (
                         ', '.join(sorted(invalid_apps))))
 
-    def generate_changesets(self, connection, app_names, author):
+    def generate_changesets(
+            self, connection, app_names, author, fake, skip_errors):
+
         loader = MigrationLoader(connection)
         graph = loader.graph
         if app_names:
@@ -75,12 +87,32 @@ class Command(BaseCommand):
         for app_label, name in to_generate:
             migration = executor.loader.get_migration_by_prefix(
                                                         app_label, name)
+            self.output_transaction = migration.atomic
+
             targets = [(app_label, migration.name)]
             forward_plan = [(executor.loader.graph.nodes[targets[0]], False)]
             backward_plan = [(executor.loader.graph.nodes[targets[0]], True)]
 
-            sql_forward = executor.collect_sql(forward_plan)
-            sql_backward = executor.collect_sql(backward_plan)
+            try:
+                sql_forward = executor.collect_sql(forward_plan)
+            except Exception as ex:
+                if skip_errors:
+                    sql_forward = ['-- skipped due to exception: %s' % ex]
+                else:
+                    raise
+
+            try:
+                sql_backward = executor.collect_sql(backward_plan)
+            except Exception as ex:
+                if skip_errors:
+                    sql_backward = ['-- skipped due to exception: %s' % ex]
+                else:
+                    raise
+
+            changeset_id = u'django-%s-%s' % (app_label, migration.name)
+
+            if fake:
+                changeset_id += '-faked'
 
             forward_version = (
                     'insert into django_migrations (app, name, applied) '
@@ -91,16 +123,18 @@ class Command(BaseCommand):
                     'app=\'%s\' and name=\'%s\';' % (
                             app_label, migration.name))
 
-            print('    <changeSet id="django-%s-%s" author="%s">' % (
-                app_label, migration.name, author))
-            print('        <sql><![CDATA[')
-            print('            '+'\n            '.join(sql_forward))
-            print('        ]]></sql>')
+            print('    <changeSet id="%s" author="%s">' % (
+                                            changeset_id, author))
+            if not fake:
+                print('        <sql><![CDATA[')
+                print('            '+'\n            '.join(sql_forward))
+                print('        ]]></sql>')
             print('        <sql>%s</sql>' % forward_version)
             print('        <rollback>')
-            print('            <sql><![CDATA[')
-            print('            '+'\n            '.join(sql_backward))
-            print('            ]]></sql>')
+            if not fake:
+                print('            <sql><![CDATA[')
+                print('            '+'\n            '.join(sql_backward))
+                print('            ]]></sql>')
             print('            <sql>%s</sql>' % backward_version)
             print('        </rollback>')
             print('    </changeSet>')

--- a/liquimigrate/management/commands/makechangesetssql.py
+++ b/liquimigrate/management/commands/makechangesetssql.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from .base import BaseChangesetCommand
+from ... import changesets
+
+
+class Command(BaseChangesetCommand):
+    help = "Generates SQL changesets for each unapplied Django migration"
+
+    def handle_changeset_command(self, connection, app_names, **options):
+        docstr = changesets.generate_changesets_text(
+                connection, app_names, fake=options['fake'],
+                skip_errors=options['skip_errors'], author=options['author'],
+                indent=options['indent'])
+        print(docstr)

--- a/liquimigrate/management/commands/makemigrations.py
+++ b/liquimigrate/management/commands/makemigrations.py
@@ -1,5 +1,8 @@
+from six.moves import input
+
 try:
-    from django.core.management.commands.makemigrations import Command as MigrateCommand
+    from django.core.management.commands.makemigrations import (
+            Command as MigrateCommand)
 except ImportError:
     from django.core.management.base import BaseCommand, CommandError
     MigrateCommand = None
@@ -14,9 +17,9 @@ if MigrateCommand:
 
         def handle(self, *args, **options):
             if options.get("interactive"):
-                confirm = raw_input("""
-You have requested to generate migration files using standard Django 1.7+ mechanism.
-This CONFLICTS WITH LIQUIMIGRATE.
+                confirm = input("""
+You have requested to generate migration files using standard Django 1.7+
+mechanism.  This CONFLICTS WITH LIQUIMIGRATE.
 Are you sure you want to do this?
 
 Type 'yes' to continue, or 'no' to cancel: """)
@@ -24,9 +27,9 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 confirm = "yes"
 
             if confirm == "yes":
-                super(Command, self).handle(**options)
+                super(Command, self).handle(*args, **options)
             else:
-                print "Making migrations cancelled."
+                print("Making migrations cancelled.")
 else:
     class Command(BaseCommand):
         def handle(self, *args, **kwargs):

--- a/liquimigrate/management/commands/migrate.py
+++ b/liquimigrate/management/commands/migrate.py
@@ -1,5 +1,8 @@
+from six.moves import input
+
 try:
-    from django.core.management.commands.migrate import Command as MigrateCommand
+    from django.core.management.commands.migrate import (
+            Command as MigrateCommand)
 except ImportError:
     from django.core.management.base import BaseCommand, CommandError
     MigrateCommand = None
@@ -14,7 +17,7 @@ if MigrateCommand:
 
         def handle(self, *args, **options):
             if options.get("interactive"):
-                confirm = raw_input("""
+                confirm = input("""
 You have requested a database migration using standard Django 1.7+ mechanism.
 This CONFLICTS WITH LIQUIMIGRATE.
 Are you sure you want to do this?
@@ -24,9 +27,9 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 confirm = "yes"
 
             if confirm == "yes":
-                super(Command, self).handle(**options)
+                super(Command, self).handle(*args, **options)
             else:
-                print "Migrate cancelled."
+                print("Migrate cancelled.")
 else:
     class Command(BaseCommand):
         def handle(self, *args, **kwargs):

--- a/liquimigrate/management/commands/squashmigrations.py
+++ b/liquimigrate/management/commands/squashmigrations.py
@@ -1,5 +1,8 @@
+from six.moves import input
+
 try:
-    from django.core.management.commands.squashmigrations import Command as MigrateCommand
+    from django.core.management.commands.squashmigrations import (
+            Command as MigrateCommand)
 except ImportError:
     from django.core.management.base import BaseCommand, CommandError
     MigrateCommand = None
@@ -14,7 +17,7 @@ if MigrateCommand:
 
         def handle(self, *args, **options):
             if options.get("interactive"):
-                confirm = raw_input("""
+                confirm = input("""
 You have requested to squash migrations using standard Django 1.7+ mechanism.
 This CONFLICTS WITH LIQUIMIGRATE.
 Are you sure you want to do this?
@@ -24,9 +27,9 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 confirm = "yes"
 
             if confirm == "yes":
-                super(Command, self).handle(**options)
+                super(Command, self).handle(*args, **options)
             else:
-                print "Squashing migrations cancelled."
+                print("Squashing migrations cancelled.")
 else:
     class Command(BaseCommand):
         def handle(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
+        'six'
 ]
 
 test_requirements = [
@@ -20,7 +21,7 @@ test_requirements = [
 
 setup(
     name='liquimigrate',
-    version='0.7.0',
+    version='0.7.1',
     description="Liquibase migrations with django",
     long_description=readme + '\n\n' + history,
     author="Marek Wywiał",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='liquimigrate',
-    version='0.8.0',
+    version='0.8.0-dev2',
     description="Liquibase migrations with django",
     long_description=readme + '\n\n' + history,
     author="Marek Wywiał",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='liquimigrate',
-    version='0.7.0',
+    version='0.8.0',
     description="Liquibase migrations with django",
     long_description=readme + '\n\n' + history,
     author="Marek Wywiał",


### PR DESCRIPTION
Hi. 

Here is PR with `makechangesets` command which gets Django's internal migrations and produces  changesets for them. This gives possiblity to sync any migrations delivered with Django or reusable apps, to Liquibase's changesets without necessity of manual writing of  changesets.

Limitations:
* only raw SQL is used
* no python migrations are transferred (this is badly done in Django)
* changesets are displayed on stdout, no changelog file is affected
* only XML output is upported

Please take a look and let's talk how to improve this.