### PR TITLE
fix #12: not passing *args to original commands

### DIFF
--- a/liquimigrate/management/commands/makemigrations.py
+++ b/liquimigrate/management/commands/makemigrations.py
@@ -1,5 +1,8 @@
+from six.moves import input
+
 try:
-    from django.core.management.commands.makemigrations import Command as MigrateCommand
+    from django.core.management.commands.makemigrations import (
+            Command as MigrateCommand)
 except ImportError:
     from django.core.management.base import BaseCommand, CommandError
     MigrateCommand = None
@@ -14,9 +17,9 @@ if MigrateCommand:
 
         def handle(self, *args, **options):
             if options.get("interactive"):
-                confirm = raw_input("""
-You have requested to generate migration files using standard Django 1.7+ mechanism.
-This CONFLICTS WITH LIQUIMIGRATE.
+                confirm = input("""
+You have requested to generate migration files using standard Django 1.7+
+mechanism.  This CONFLICTS WITH LIQUIMIGRATE.
 Are you sure you want to do this?
 
 Type 'yes' to continue, or 'no' to cancel: """)
@@ -24,9 +27,9 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 confirm = "yes"
 
             if confirm == "yes":
-                super(Command, self).handle(**options)
+                super(Command, self).handle(*args, **options)
             else:
-                print "Making migrations cancelled."
+                print("Making migrations cancelled.")
 else:
     class Command(BaseCommand):
         def handle(self, *args, **kwargs):

--- a/liquimigrate/management/commands/migrate.py
+++ b/liquimigrate/management/commands/migrate.py
@@ -1,5 +1,8 @@
+from six.moves import input
+
 try:
-    from django.core.management.commands.migrate import Command as MigrateCommand
+    from django.core.management.commands.migrate import (
+            Command as MigrateCommand)
 except ImportError:
     from django.core.management.base import BaseCommand, CommandError
     MigrateCommand = None
@@ -14,7 +17,7 @@ if MigrateCommand:
 
         def handle(self, *args, **options):
             if options.get("interactive"):
-                confirm = raw_input("""
+                confirm = input("""
 You have requested a database migration using standard Django 1.7+ mechanism.
 This CONFLICTS WITH LIQUIMIGRATE.
 Are you sure you want to do this?
@@ -24,9 +27,9 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 confirm = "yes"
 
             if confirm == "yes":
-                super(Command, self).handle(**options)
+                super(Command, self).handle(*args, **options)
             else:
-                print "Migrate cancelled."
+                print("Migrate cancelled.")
 else:
     class Command(BaseCommand):
         def handle(self, *args, **kwargs):

--- a/liquimigrate/management/commands/squashmigrations.py
+++ b/liquimigrate/management/commands/squashmigrations.py
@@ -1,5 +1,8 @@
+from six.moves import input
+
 try:
-    from django.core.management.commands.squashmigrations import Command as MigrateCommand
+    from django.core.management.commands.squashmigrations import (
+            Command as MigrateCommand)
 except ImportError:
     from django.core.management.base import BaseCommand, CommandError
     MigrateCommand = None
@@ -14,7 +17,7 @@ if MigrateCommand:
 
         def handle(self, *args, **options):
             if options.get("interactive"):
-                confirm = raw_input("""
+                confirm = input("""
 You have requested to squash migrations using standard Django 1.7+ mechanism.
 This CONFLICTS WITH LIQUIMIGRATE.
 Are you sure you want to do this?
@@ -24,9 +27,9 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 confirm = "yes"
 
             if confirm == "yes":
-                super(Command, self).handle(**options)
+                super(Command, self).handle(*args, **options)
             else:
-                print "Squashing migrations cancelled."
+                print("Squashing migrations cancelled.")
 else:
     class Command(BaseCommand):
         def handle(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
+        'six'
 ]
 
 test_requirements = [
@@ -20,7 +21,7 @@ test_requirements = [
 
 setup(
     name='liquimigrate',
-    version='0.7.0',
+    version='0.7.1',
     description="Liquibase migrations with django",
     long_description=readme + '\n\n' + history,
     author="Marek Wywiał",


### PR DESCRIPTION
This should fix #12 
I've added `six` dep for compatibility with pep8 and py3  